### PR TITLE
PyPy support

### DIFF
--- a/deploy/flags.ini.tpl
+++ b/deploy/flags.ini.tpl
@@ -3,8 +3,7 @@ socket = 127.0.0.1:8090
 master = true
 virtualenv = {{ VENV_DIR }}
 pythonpath = {{ REPO_DIR }}
-module = server
-callable = app
+pypy-wsgi-file = server.py
 logger = rsyslog:{{ SYSLOG_HOST | default("syslog-aws.dubizzlecloud.internal") }}:{{ SYSLOG_PORT | default("1122") }},{{ APP_NAME }}_uwsgi
 logto = /var/log/dubizzle/{{ APP_NAME }}_uwsgi.log
 processes = 4
@@ -20,5 +19,4 @@ evil-reload-on-as = 2048
 die-on-term
 # for newrelic
 post-buffering = 20971520
-max-requests=1000
 buffer-size = 32768

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.16
+FROM jeethu/baseimage-pypy:0.9.16.1
 
 MAINTAINER Dareen Alhiyari <dareen@dubizzle.com>
 
@@ -16,17 +16,7 @@ ENV USER_LOGGING_DIR /var/log/$USER
 RUN set -e; \
     add-apt-repository ppa:chris-lea/nginx-devel; \
     apt-get update -y; \
-    apt-get install -y make \
-        libcurl4-openssl-dev \
-        python2.7-dev \
-        python-virtualenv  \
-        nginx \
-        zlib1g-dev \
-        gettext \
-        libffi-dev \
-        libevent-dev \
-        zlibc \
-        python-setuptools
+    apt-get install -y nginx gcc
 
 ADD requirements.txt /tmp/
 
@@ -36,8 +26,9 @@ RUN set -e; \
     chown -R $USER:$USER $USER_DIR; \
     mkdir -p $USER_LOGGING_DIR; \
     chmod a+rw -R $USER_LOGGING_DIR; \
-    su - $USER -l -c "virtualenv --system-site-packages $VENV_DIR"; \
-    su - $USER -l -c "$VENV_PIP install --upgrade -r /tmp/requirements.txt"
+    su - $USER -l -c "virtualenv-pypy $VENV_DIR"; \
+    su - $USER -l -c "$VENV_PIP install --upgrade -r /tmp/requirements.txt"; \
+    su - $USER -l -c "rm -rf $USER_DIR/.cache/pip/wheels"
 
 ADD archive.tar.gz $REPO_DIR
 

--- a/docker/services/uwsgi.sh
+++ b/docker/services/uwsgi.sh
@@ -5,4 +5,6 @@ source /etc/container_environment.sh
 # Generate the uwsgi ini file from template and the container environment.
 su dubizzle -l -c "$VENV_DIR/bin/envtpl < $REPO_DIR/deploy/flags.ini.tpl > $REPO_DIR/deploy/flags.ini"
 
-exec /sbin/setuser dubizzle $VENV_DIR/bin/uwsgi --ini $REPO_DIR/deploy/flags.ini
+cd "$REPO_DIR"
+
+exec /sbin/setuser dubizzle "$VENV_DIR/bin/uwsgi" --ini "$REPO_DIR/deploy/flags.ini"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
-envtpl==0.3.2
+envtpl==0.4.1
 redis==2.10.3
-envparse==0.1.5
-bottleCBV
-uWSGI==1.9.20
+envparse==0.1.6
+BottleCBV==0.2
+uWSGI==2.0.11.1
 kazoo==2.0
 WTForms==2.0.2
 schema==0.3.1

--- a/server.py
+++ b/server.py
@@ -11,14 +11,14 @@ from flags.conf import settings
 
 logger = logging.getLogger(__name__)
 
-app = Bottle()
+application = Bottle()
 
-APIView.register(app)
+APIView.register(application)
 if settings.ADMIN_MODE:
-    register_ui_views(app)
+    register_ui_views(application)
 
 
-@app.route("/check")
+@application.route("/check")
 def check():
     return "Up and running :)"
 
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         "%s: %s" % (key, value) for key, value in app_kwargs.items()
     ]))
 
-    run(app, **app_kwargs)
+    run(application, **app_kwargs)
 
 # wrap the bottle app with newrelic wrapper
 if settings.PRODUCTION_MODE:
@@ -49,4 +49,4 @@ if settings.PRODUCTION_MODE:
         )
 
     newrelic.agent.initialize(settings.NEW_RELIC_CONFIG)
-    app = newrelic.agent.WSGIApplicationWrapper(app)
+    application = newrelic.agent.WSGIApplicationWrapper(application)


### PR DESCRIPTION
Switched the Python interpreter from CPython to the latest versions of PyPy (2.6.0, compatible with CPython 2.7.9). Had to switch the docker base image from [phusion base image](https://github.com/phusion/baseimage-docker/) to my [extended base image](https://github.com/jeethu/baseimage-pypy) which has the PyPy interpreter and the shared library (required for uWSGI support) installed. Also, upgraded a bunch of python packages.  Expect some significant [speedups](http://speed.pypy.org/).